### PR TITLE
PR merge시 label에 맞추어 패키지의 버전을 자동으로 올리는 worflow 추가

### DIFF
--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -1,0 +1,74 @@
+name: Update Version on PR Merge
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  update_version:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the code
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Set up Python
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+
+      # Install poetry
+      - name: Install Poetry
+        run: |
+          pipx install poetry==1.8.4
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      # Install project dependencies
+      - name: Install dependencies
+        run: poetry install
+
+      # Determine the version bump type
+      - name: Determine version bump type
+        id: version_type
+        run: |
+          JSON_LABELS='${{ toJson(github.event.pull_request.labels) }}'
+          if echo "$JSON_LABELS" | jq -e '.[] | select(.name == "major")' >/dev/null; then
+            echo "type=major" >> $GITHUB_ENV
+          elif echo "$JSON_LABELS" | jq -e '.[] | select(.name == "minor")' >/dev/null; then
+            echo "type=minor" >> $GITHUB_ENV
+          elif echo "$JSON_LABELS" | jq -e '.[] | select(.name == "patch")' >/dev/null; then
+            echo "type=patch" >> $GITHUB_ENV
+          else
+            echo "No version bump label found."
+            exit 1
+          fi
+
+      # Bump the version using poetry
+      - name: Bump version
+        run: |
+          poetry version ${{ env.type }}
+          NEW_VERSION=$(poetry version -s)
+          echo "new_version=${NEW_VERSION}" >> $GITHUB_ENV
+
+      # Commit the version change
+      - name: Commit version update
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "Bump version to ${{ env.new_version }}"
+
+      # Push the changes
+      - name: Push changes
+        run: |
+          git push origin HEAD
+
+      # Create a Git tag
+      - name: Create Git tag
+        run: |
+          git tag -a v${{ env.new_version }} -m "Version ${{ env.new_version }}"
+          git push origin v${{ env.new_version }}


### PR DESCRIPTION
## 1. 작업 개요
PR이 `merge`될 때 라벨(`major`, `minor`, `patch`)을 기반으로 프로젝트의 버전을 자동으로 업데이트하는 GitHub Actions 워크플로우를 추가했습니다.

## 2. 주요 변경사항
1. PR 라벨 기반 버전 업데이트:
   - `major`, `minor`, `patch` 라벨에 따라 `poetry version` 명령을 실행.
   - 예: `patch` 라벨 → `poetry version patch`.

2. 자동화된 커밋 및 태그 생성:
   - 변경된 버전(`pyproject.toml`)을 커밋 후 태그를 생성하고 원격 저장소에 푸시.

3. 상기 기능의 구현을 위한 GitHub Actions 워크플로우 추가:
   - 라벨 확인, 버전 변경, 커밋 및 태그 푸시 진행

## 3. 작동 방식
1. PR 라벨 확인: merge된 PR의 라벨(`major`, `minor`, `patch`)로 버전 타입 결정.
2. 버전 변경: poetry 명령어를 사용해 버전 업데이트.
3. 커밋 및 태그: 변경사항 커밋 후 태그 생성 및 푸시.
