### PR TITLE
Context params 처리 로직 개선 (#10)

### DIFF
--- a/kakao_chatbot/context.py
+++ b/kakao_chatbot/context.py
@@ -23,13 +23,13 @@ class Context(ParentPayload, SkillTemplate):
         name (str): 컨텍스트의 이름
         lifespan (int): 컨텍스트의 남은 횟수
         ttl (int, optional): 컨텍스트가 유지되는 시간
-        params (dict, optional): 컨텍스트의 추가 정보
+        params (Dict, optional): 컨텍스트의 추가 정보
 
     Attributes:
         name (str): 컨텍스트의 이름
         lifespan (int): 컨텍스트의 남은 횟수
         ttl (int): 컨텍스트가 유지되는 시간
-        params (dict): 컨텍스트의 추가 정보
+        params (Dict[str, ContextParam]): 컨텍스트의 추가 정보
 
     Examples:
         >>> context = Context(
@@ -37,7 +37,10 @@ class Context(ParentPayload, SkillTemplate):
         ...     lifespan=1,
         ...     ttl=600,
         ...     params={
-        ...         "key": "value"
+        ...         "key": {
+        ...             "value": "value",
+        ...             "resolved_value": "resolved_value"
+        ...         }
         ...     }
         ... )
         >>> context.render()
@@ -63,7 +66,7 @@ class Context(ParentPayload, SkillTemplate):
         self.name = name
         self.lifespan = lifespan
         self.ttl = ttl
-        self.params = params
+        self.params: Dict[str, ContextParam] = params or {}
 
     @classmethod
     def from_dict(cls, data: Dict) -> "Context":
@@ -77,7 +80,10 @@ class Context(ParentPayload, SkillTemplate):
             ...     "lifespan": 1,
             ...     "ttl": 600,
             ...     "params": {
-            ...         "key": "value"
+            ...         "key": {
+            ...             "value": "value",
+            ...             "resolvedValue": "resolved_value"
+            ...         }
             ...     }
             ... }
 
@@ -87,11 +93,20 @@ class Context(ParentPayload, SkillTemplate):
         Returns:
             Context: 변환된 Context 객체
         """
-        return cls(**data)
+        name = data.get("name", "")
+        lifespan = data.get("lifespan", "")
+        ttl = data.get("ttl", None)
+        params = {
+            key: ContextParam.from_dict(value)
+            for key, value in data.get("params", {}).items()
+        }
+        return cls(name, lifespan, ttl, params)
 
     def render(self) -> Dict:
         """Context 객체를 카카오톡 응답 규칙에 맞게 딕셔너리로 변환합니다.
 
+        params에 있는 ContextParam 객체는 render 메서드를 통해 value 값을 반환합니다.
+        만약, params에 ContextParam 객체가 아닌 다른 객체가 들어있을 경우, 그대로 반환합니다.
         반환되는 딕셔너리는 다음과 같은 형태입니다.
 
         Examples:
@@ -112,7 +127,10 @@ class Context(ParentPayload, SkillTemplate):
             "name": self.name,
             "lifeSpan": self.lifespan,
             "ttl": self.ttl,
-            "params": self.params,
+            "params": {
+                key: param.render() if isinstance(param, ContextParam) else param
+                for key, param in self.params.items()
+            } if self.params else None
         }
         return self.remove_none_item(response)
 
@@ -128,3 +146,87 @@ class Context(ParentPayload, SkillTemplate):
         validate_str(self.name)
         validate_int(self.lifespan, self.ttl)
         validate_type(dict, self.params)
+
+
+class ContextParam(ParentPayload, SkillTemplate):
+    """컨텍스트의 Param 정보를 담는 클래스입니다.
+
+    컨텍스트의 Param 정보는 컨텍스트 정보에 추가적인 정보를 담을 때 사용됩니다.
+    Payload에 담겨지는 컨텍스트 정보의 Params는 Stringfy된 JSON 형태로 전달됩니다.
+    이떄, `{key : {"value" : value, "resolved_value" : resolved_value}}` 형태로 전달됩니다.
+    이후 `Response`에서는 `[key : value]` 형태로 전달해야합니다.
+    이 클래스는 이러한 특성에 맞게, `value`와 `resolved_value`를 가지도록 정의됩니다.
+    또한, `render()` 메서드를 통해 `value` 값 만을 반환하도록 정의됩니다.
+
+    Args:
+        value (str): 컨텍스트의 Param의 value
+        resolved_value (str): 컨텍스트의 Param의 resolved_value
+
+    Attributes:
+        value (str): 컨텍스트의 Param의 value
+        resolved_value (str): 컨텍스트의 Param의 resolved_value
+
+    Examples:
+        >>> context_param = ContextParam(
+        ...     value="value_str",
+        ...     resolved_value="resolved_value"
+        ... )
+        >>> context_param.render()
+        "value_str"
+    """
+
+    def __init__(self, value: str, resolved_value: str):
+        """ContextParam 객체를 초기화합니다."""
+        self.value = value
+        self.resolved_value = resolved_value
+
+    @classmethod
+    def from_dict(cls, data: dict) -> 'ContextParam':
+        """딕셔너리를 ContextParam 객체로 변환합니다.
+
+        변환할 딕셔너리는 다음과 같은 형태입니다.
+
+        Examples:
+            >>> data = {
+            ...     "value": "value",
+            ...     "resolvedValue": "resolved_value"
+            ... }
+
+        Args:
+            data (dict): 변환할 딕셔너리
+
+        Returns:
+            ContextParam: 변환된 ContextParam 객체
+        """
+        value = data.get("value", "")
+        resolved_value = data.get("resolvedValue", "")
+        return cls(value, resolved_value)
+
+    def render(self) -> str:  # type: ignore
+        """ContextParam 객체의 value를 반환합니다.
+
+        이 패키지의 다른 클래스들과 달리, ContextParam 객체는 value만을 반환해야 합니다.
+        이는 ContextParam 객체의 특성에 맞게, value 값만을 반환하기 위함입니다
+
+        Returns:
+            str: ContextParam 객체의 value
+
+        Examples:
+            >>> context_param = ContextParam(
+            ...     value="value_str",
+            ...     resolved_value="resolved_value"
+            ... )
+            >>> context_param.render()
+            "value_str"
+        """
+        self.validate()
+        return self.value
+
+    def validate(self):
+        """ContextParam 객체의 유효성을 검사합니다.
+
+        Raises:
+            InvalidTypeError: value가 str이 아닐 경우 발생합니다.
+            InvalidTypeError: resolved_value가 str이 아닐 경우 발생합니다.
+        """
+        validate_str(self.value, self.resolved_value)


### PR DESCRIPTION
해당 PR은 #10 이슈를 해결하기 위한 Context의 `params` 처리 로직 및 코드 일관성 개선사항을 포함합니다.

**주요 변경사항**  
- Payload와 Response에서 서로 다른 형식으로 전달되는 `params` 필드 처리 로직 개선  
  - Payload: `params={"key": {"value":"value","resolved_value":"resolved_value"}}`  
  - Response: `params={"key":"value"}`
- `ContextParam` 클래스를 도입하여 Payload에서 전달되는 params를 변환하고, Response에서는 value만 반환하도록 개선
- `validate()` 메서드에서 `ContextParam` 객체 유효성 검사 추가

위 변경으로 Payload와 Response 간 `params` 구조 불일치 문제를 해결하고, 코드 가독성과 일관성을 높였습니다.