### PR TITLE
Change User.properties type to UserProperties

### DIFF
--- a/kakao_chatbot/input.py
+++ b/kakao_chatbot/input.py
@@ -448,7 +448,7 @@ class User(ParentPayload):
         self,
         ID: str,
         TYPE: str,
-        properties: Optional[Dict] = None,
+        properties: UserProperties = None,
     ):
         """User 객체를 생성하는 메서드입니다.
 
@@ -475,7 +475,7 @@ class User(ParentPayload):
         """
         ID = data.get("id", "")
         TYPE = data.get("type", "")
-        properties = data.get("properties", {})
+        properties = UserProperties.from_dict(data.get("properties", {}))
         return cls(ID=ID, TYPE=TYPE, properties=properties)
 
 


### PR DESCRIPTION
Update the User object to use UserProperties for its properties type, enhancing type safety and clarity.

기존에도 UserProperties 클래스가 존재했으나, User.properties 와 연결되지 않았고 User.properties의 타입은 단순 dict로 처리되었습니다. 이를 User 객체와 연결하는 pr입니다.